### PR TITLE
Allow tests to run under globally installed phpunit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <phpunit backupGlobals="true"
          backupStaticAttributes="false"
          cacheTokens="false"
-         colors="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
@@ -14,7 +13,8 @@
          stopOnIncomplete="false"
          stopOnSkipped="false"
          testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
-         verbose="false">
+         verbose="false"
+         bootstrap="tests/autoload.php">
 
   <testsuites>
     <testsuite name="My Test Suite">
@@ -37,4 +37,8 @@
       </exclude>
     </whitelist>
   </filter>
+
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
 </phpunit>

--- a/tests/LatLngTest.php
+++ b/tests/LatLngTest.php
@@ -2,11 +2,6 @@
 
 namespace PHPCoord;
 
-require_once(__DIR__ . '/../OSRef.php');
-require_once(__DIR__ . '/../LatLng.php');
-require_once(__DIR__ . '/../RefEll.php');
-require_once(__DIR__ . '/../UTMRef.php');
-
 class LatLngTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -2,11 +2,6 @@
 
 namespace PHPCoord;
 
-require_once(__DIR__ . '/../OSRef.php');
-require_once(__DIR__ . '/../LatLng.php');
-require_once(__DIR__ . '/../RefEll.php');
-require_once(__DIR__ . '/../UTMRef.php');
-
 class OSRefTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/UTMRefTest.php
+++ b/tests/UTMRefTest.php
@@ -2,11 +2,6 @@
 
 namespace PHPCoord;
 
-require_once(__DIR__ . '/../OSRef.php');
-require_once(__DIR__ . '/../LatLng.php');
-require_once(__DIR__ . '/../RefEll.php');
-require_once(__DIR__ . '/../UTMRef.php');
-
 class UTMRefTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * An autoloader for the tests
+ */
+spl_autoload_register(function ($class) {
+    if(!preg_match('|PHPCoord\\\\(?<className>.*)|', $class, $matches)) return;
+    $classFile=__DIR__ . '/../' . strtr($matches['className'],array('/'=>'','\\'=>'/')) . '.php';
+    if(!file_exists($classFile)) return;
+    require_once($classFile);
+});


### PR DESCRIPTION
Tested OK under phpunit 5.0, php 5.6

Fixed this error in my environment:
$ phpunit
PHP Fatal error:  Class 'PHPCoord\TransverseMercator' not found in /cygdrive/c/Users/Jim/project/vendor/php-coord/php-coord/OSRef.php on line 18