### PR TITLE
Add toEightFigureString and toTenFigureString

### DIFF
--- a/OSRef.php
+++ b/OSRef.php
@@ -87,90 +87,89 @@ class OSRef extends TransverseMercator
     }
 
     /**
+     * Convert this grid reference into a grid reference string of a 
+     * given length (2, 4, 6, 8 or  10) including the two-character 
+     * designation for the 100km square. e.g. TG514131.
+     * @return string
+     */
+    private function toGridReference($length)
+    {
+
+        $halfLangth = $length / 2;
+
+        $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
+        $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
+
+
+        $adjustedX = $this->x + 1000000;
+        $adjustedY = $this->y + 500000;
+        $majorSquaresEast = floor($adjustedX / 500000);
+        $majorSquaresNorth = floor($adjustedY / 500000);
+        $majorLetterIndex = (int)(5 * $majorSquaresNorth + $majorSquaresEast);
+        $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
+
+        //second (minor) letter is 100km grid sq, origin at 0,0 of this square
+        $minorSquaresEast = $easting[0] % 5;
+        $minorSquaresNorth = $northing[0] % 5;
+        $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
+        $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
+
+        return $majorLetter . $minorLetter . substr($easting, 1, $halfLangth) . substr($northing, 1, $halfLangth);
+    }
+
+    /**
+     * Convert this grid reference into a string using a standard two-figure
+     * grid reference including the two-character designation for the 100km
+     * square. e.g. TG51 (10km square).
+     * @return string
+     */
+    public function toTwoFigureReference()
+    {
+        return $this->toGridReference(2);
+    }
+
+    /**
+     * Convert this grid reference into a string using a standard four-figure
+     * grid reference including the two-character designation for the 100km
+     * square. e.g. TG5113 (1km square).
+     * @return string
+     */
+    public function toFourFigureReference()
+    {
+        return $this->toGridReference(4);
+    }
+
+    /**
      * Convert this grid reference into a string using a standard six-figure
      * grid reference including the two-character designation for the 100km
-     * square. e.g. TG514131.
+     * square. e.g. TG514131 (100m square).
      * @return string
      */
     public function toSixFigureReference()
     {
-
-        $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
-        $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
-
-
-        $adjustedX = $this->x + 1000000;
-        $adjustedY = $this->y + 500000;
-        $majorSquaresEast = floor($adjustedX / 500000);
-        $majorSquaresNorth = floor($adjustedY / 500000);
-        $majorLetterIndex = (int)(5 * $majorSquaresNorth + $majorSquaresEast);
-        $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
-
-        //second (minor) letter is 100km grid sq, origin at 0,0 of this square
-        $minorSquaresEast = $easting[0] % 5;
-        $minorSquaresNorth = $northing[0] % 5;
-        $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
-        $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
-
-        return $majorLetter . $minorLetter . substr($easting, 1, 3) . substr($northing, 1, 3);
+        return $this->toGridReference(6);
     }
-    
+
     /**
      * Convert this grid reference into a string using a standard eight-figure
      * grid reference including the two-character designation for the 100km
-     * square. e.g. TG51411311.
+     * square. e.g. TG51431312 (10m square).
      * @return string
      */
     public function toEightFigureReference()
-        {
-
-        $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
-        $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
-
-
-        $adjustedX = $this->x + 1000000;
-        $adjustedY = $this->y + 500000;
-        $majorSquaresEast = floor($adjustedX / 500000);
-        $majorSquaresNorth = floor($adjustedY / 500000);
-        $majorLetterIndex = (int)(5 * $majorSquaresNorth + $majorSquaresEast);
-        $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
-
-        //second (minor) letter is 100km grid sq, origin at 0,0 of this square
-        $minorSquaresEast = $easting[0] % 5;
-        $minorSquaresNorth = $northing[0] % 5;
-        $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
-        $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
-
-        return $majorLetter . $minorLetter . substr($easting, 1, 4) . substr($northing, 1, 4);
+    {
+        return $this->toGridReference(8);
     }
 
     /**
      * Convert this grid reference into a string using a standard ten-figure
      * grid reference including the two-character designation for the 100km
-     * square. e.g. TG5141213112.
+     * square. e.g. TG5143113121 (1m square).
      * @return string
      */
     public function toTenFigureReference()
     {
-
-        $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
-        $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
-
-
-        $adjustedX = $this->x + 1000000;
-        $adjustedY = $this->y + 500000;
-        $majorSquaresEast = floor($adjustedX / 500000);
-        $majorSquaresNorth = floor($adjustedY / 500000);
-        $majorLetterIndex = (int)(5 * $majorSquaresNorth + $majorSquaresEast);
-        $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
-
-        //second (minor) letter is 100km grid sq, origin at 0,0 of this square
-        $minorSquaresEast = $easting[0] % 5;
-        $minorSquaresNorth = $northing[0] % 5;
-        $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
-        $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
-
-        return $majorLetter . $minorLetter . substr($easting, 1, 5) . substr($northing, 1, 5);
+        return $this->toGridReference(10);
     }
 
     /**

--- a/OSRef.php
+++ b/OSRef.php
@@ -121,35 +121,27 @@ class OSRef extends TransverseMercator
      * square. e.g. TG51411311.
      * @return string
      */
-    public function toEightFigureString()
-    {
+    public function toEightFigureReference()
+        {
 
-        $easting = str_pad($this->easting, 6, 0, STR_PAD_LEFT);
-        $northing = str_pad($this->northing, 6, 0, STR_PAD_LEFT);
+        $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
+        $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
 
-        $hundredkmE = $easting[0];
-        $hundredkmN = $northing[0];
 
-        if ($hundredkmN < 5 && $hundredkmE < 5) {
-            $firstLetter = 'S';
-        } else if ($hundredkmN < 5 && $hundredkmE >= 5) {
-            $firstLetter = 'T';
-        } else if ($hundredkmN < 10 && $hundredkmE < 5) {
-            $firstLetter = 'N';
-        } else if ($hundredkmN < 10 && $hundredkmE >= 5) {
-            $firstLetter = 'O';
-        } else {
-            $firstLetter = 'H';
-        }
+        $adjustedX = $this->x + 1000000;
+        $adjustedY = $this->y + 500000;
+        $majorSquaresEast = floor($adjustedX / 500000);
+        $majorSquaresNorth = floor($adjustedY / 500000);
+        $majorLetterIndex = (int)(5 * $majorSquaresNorth + $majorSquaresEast);
+        $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
 
-        $index = 65 + ((4 - ($hundredkmN % 5)) * 5) + ($hundredkmE % 5);
-        if ($index >= 73) {
-            //skip the letter I
-            $index++;
-        }
-        $secondLetter = chr($index);
+        //second (minor) letter is 100km grid sq, origin at 0,0 of this square
+        $minorSquaresEast = $easting[0] % 5;
+        $minorSquaresNorth = $northing[0] % 5;
+        $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
+        $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
 
-        return $firstLetter . $secondLetter . substr($easting, 1, 4) . substr($northing, 1, 4);
+        return $majorLetter . $minorLetter . substr($easting, 1, 4) . substr($northing, 1, 4);
     }
 
     /**
@@ -158,35 +150,27 @@ class OSRef extends TransverseMercator
      * square. e.g. TG5141213112.
      * @return string
      */
-    public function toTenFigureString()
+    public function toTenFigureReference()
     {
 
-        $easting = str_pad($this->easting, 6, 0, STR_PAD_LEFT);
-        $northing = str_pad($this->northing, 6, 0, STR_PAD_LEFT);
+        $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
+        $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
 
-        $hundredkmE = $easting[0];
-        $hundredkmN = $northing[0];
 
-        if ($hundredkmN < 5 && $hundredkmE < 5) {
-            $firstLetter = 'S';
-        } else if ($hundredkmN < 5 && $hundredkmE >= 5) {
-            $firstLetter = 'T';
-        } else if ($hundredkmN < 10 && $hundredkmE < 5) {
-            $firstLetter = 'N';
-        } else if ($hundredkmN < 10 && $hundredkmE >= 5) {
-            $firstLetter = 'O';
-        } else {
-            $firstLetter = 'H';
-        }
+        $adjustedX = $this->x + 1000000;
+        $adjustedY = $this->y + 500000;
+        $majorSquaresEast = floor($adjustedX / 500000);
+        $majorSquaresNorth = floor($adjustedY / 500000);
+        $majorLetterIndex = (int)(5 * $majorSquaresNorth + $majorSquaresEast);
+        $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
 
-        $index = 65 + ((4 - ($hundredkmN % 5)) * 5) + ($hundredkmE % 5);
-        if ($index >= 73) {
-            //skip the letter I
-            $index++;
-        }
-        $secondLetter = chr($index);
+        //second (minor) letter is 100km grid sq, origin at 0,0 of this square
+        $minorSquaresEast = $easting[0] % 5;
+        $minorSquaresNorth = $northing[0] % 5;
+        $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
+        $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
 
-        return $firstLetter . $secondLetter . substr($easting, 1, 5) . substr($northing, 1, 5);
+        return $majorLetter . $minorLetter . substr($easting, 1, 5) . substr($northing, 1, 5);
     }
 
     /**

--- a/OSRef.php
+++ b/OSRef.php
@@ -88,14 +88,14 @@ class OSRef extends TransverseMercator
 
     /**
      * Convert this grid reference into a grid reference string of a 
-     * given length (2, 4, 6, 8 or  10) including the two-character 
+     * given length (2, 4, 6, 8 or 10) including the two-character 
      * designation for the 100km square. e.g. TG514131.
      * @return string
      */
     private function toGridReference($length)
     {
 
-        $halfLangth = $length / 2;
+        $halfLength = $length / 2;
 
         $easting = str_pad($this->x, 6, 0, STR_PAD_LEFT);
         $northing = str_pad($this->y, 6, 0, STR_PAD_LEFT);
@@ -114,7 +114,7 @@ class OSRef extends TransverseMercator
         $minorLetterIndex = (int)(5 * $minorSquaresNorth + $minorSquaresEast);
         $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
 
-        return $majorLetter . $minorLetter . substr($easting, 1, $halfLangth) . substr($northing, 1, $halfLangth);
+        return $majorLetter . $minorLetter . substr($easting, 1, $halfLength) . substr($northing, 1, $halfLength);
     }
 
     /**

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -36,6 +36,26 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expected, $LatLng->__toString());
     }
 
+    public function testToTwoFigureString()
+    {
+
+        $OSRef = new OSRef(530140, 184184);
+
+        $expected = 'TQ38';
+
+        self::assertEquals($expected, $OSRef->toTwoFigureReference());
+    }
+
+    public function testToFourFigureString()
+    {
+
+        $OSRef = new OSRef(530140, 184184);
+
+        $expected = 'TQ3084';
+
+        self::assertEquals($expected, $OSRef->toFourFigureReference());
+    }
+
     public function testToSixFigureString()
     {
 
@@ -65,13 +85,13 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
 
         self::assertEquals($expected, $OSRef->toSixFigureReference());
     }
-    
-        public function testToEightFigureString()
+
+    public function testToEightFigureString()
     {
 
-        $OSRef = new OSRef(439145, 274187);
+        $OSRef = new OSRef(216600, 771200);
 
-        $expected = 'SP39147418';
+        $expected = 'NN16607120';
 
         self::assertEquals($expected, $OSRef->toEightFigureReference());
     }
@@ -79,9 +99,9 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
     public function testToTenFigureString()
     {
 
-        $OSRef = new OSRef(439145, 274187);
+        $OSRef = new OSRef(216600, 771200);
 
-        $expected = 'SP3914574187';
+        $expected = 'NN1660071200';
 
         self::assertEquals($expected, $OSRef->toTenFigureReference());
     }

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -41,44 +41,34 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expected, $LatLng->__toString());
     }
 
-    public function testToSixFigureString()
+    public function testToSixFigureReference()
     {
 
         $OSRef = new OSRef(530140, 184184);
 
         $expected = 'TQ301841';
 
-        self::assertEquals($expected, $OSRef->toSixFigureString());
+        self::assertEquals($expected, $OSRef->toSixFigureReference());
     }
 
-    public function testToSixFigureString2()
-    {
-
-        $OSRef = new OSRef(439145, 274187);
-
-        $expected = 'SP391741';
-
-        self::assertEquals($expected, $OSRef->toSixFigureString());
-    }
-
-    public function testToEightFigureString2()
+    public function testToEightFigureReference()
     {
 
         $OSRef = new OSRef(439145, 274187);
 
         $expected = 'SP39147418';
 
-        self::assertEquals($expected, $OSRef->toEightFigureString());
+        self::assertEquals($expected, $OSRef->toEightFigureReference());
     }
 
-    public function testToTenFigureString2()
+    public function testToTenFigureReference()
     {
 
         $OSRef = new OSRef(439145, 274187);
 
         $expected = 'SP3914574187';
 
-        self::assertEquals($expected, $OSRef->toTenFigureString());
+        self::assertEquals($expected, $OSRef->toTenFigureReference());
     }
 
     public function testFromSixFigureString()

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -2,6 +2,11 @@
 
 namespace PHPCoord;
 
+require_once __DIR__ . '/../OSRef.php';
+require_once __DIR__ . '/../LatLng.php';
+require_once __DIR__ . '/../RefEll.php';
+require_once __DIR__ . '/../UTMRef.php';
+
 class OSRefTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -43,7 +48,7 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
 
         $expected = 'TQ301841';
 
-        self::assertEquals($expected, $OSRef->toSixFigureReference());
+        self::assertEquals($expected, $OSRef->toSixFigureString());
     }
 
     public function testToSixFigureString2()
@@ -53,33 +58,34 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
 
         $expected = 'SP391741';
 
-        self::assertEquals($expected, $OSRef->toSixFigureReference());
+        self::assertEquals($expected, $OSRef->toSixFigureString());
     }
 
-    public function testToSixFigureString3()
+    public function testToEightFigureString2()
     {
 
-        $OSRef = new OSRef(216600, 771200);
+        $OSRef = new OSRef(439145, 274187);
 
-        $expected = 'NN166712';
+        $expected = 'SP39147418';
 
-        self::assertEquals($expected, $OSRef->toSixFigureReference());
+        self::assertEquals($expected, $OSRef->toEightFigureString());
+    }
+
+    public function testToTenFigureString2()
+    {
+
+        $OSRef = new OSRef(439145, 274187);
+
+        $expected = 'SP3914574187';
+
+        self::assertEquals($expected, $OSRef->toTenFigureString());
     }
 
     public function testFromSixFigureString()
     {
 
-        $OSRef = OSRef::fromSixFigureReference('TQ301842');
+        $OSRef = OSRef::getOSRefFromSixFigureReference('TQ301842');
         $expected = "(530100, 184200)";
-
-        self::assertEquals($expected, $OSRef->__toString());
-    }
-
-    public function testFromSixFigureString2()
-    {
-
-        $OSRef = OSRef::fromSixFigureReference('HU396753');
-        $expected = "(439600, 1175300)";
 
         self::assertEquals($expected, $OSRef->__toString());
     }

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -2,11 +2,6 @@
 
 namespace PHPCoord;
 
-require_once __DIR__ . '/../OSRef.php';
-require_once __DIR__ . '/../LatLng.php';
-require_once __DIR__ . '/../RefEll.php';
-require_once __DIR__ . '/../UTMRef.php';
-
 class OSRefTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -41,7 +36,7 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expected, $LatLng->__toString());
     }
 
-    public function testToSixFigureReference()
+    public function testToSixFigureString()
     {
 
         $OSRef = new OSRef(530140, 184184);
@@ -51,7 +46,27 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expected, $OSRef->toSixFigureReference());
     }
 
-    public function testToEightFigureReference()
+    public function testToSixFigureString2()
+    {
+
+        $OSRef = new OSRef(439145, 274187);
+
+        $expected = 'SP391741';
+
+        self::assertEquals($expected, $OSRef->toSixFigureReference());
+    }
+
+    public function testToSixFigureString3()
+    {
+
+        $OSRef = new OSRef(216600, 771200);
+
+        $expected = 'NN166712';
+
+        self::assertEquals($expected, $OSRef->toSixFigureReference());
+    }
+    
+        public function testToEightFigureString()
     {
 
         $OSRef = new OSRef(439145, 274187);
@@ -61,7 +76,7 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
         self::assertEquals($expected, $OSRef->toEightFigureReference());
     }
 
-    public function testToTenFigureReference()
+    public function testToTenFigureString()
     {
 
         $OSRef = new OSRef(439145, 274187);
@@ -74,8 +89,17 @@ class OSRefTest extends \PHPUnit_Framework_TestCase
     public function testFromSixFigureString()
     {
 
-        $OSRef = OSRef::getOSRefFromSixFigureReference('TQ301842');
+        $OSRef = OSRef::fromSixFigureReference('TQ301842');
         $expected = "(530100, 184200)";
+
+        self::assertEquals($expected, $OSRef->__toString());
+    }
+
+    public function testFromSixFigureString2()
+    {
+
+        $OSRef = OSRef::fromSixFigureReference('HU396753');
+        $expected = "(439600, 1175300)";
 
         self::assertEquals($expected, $OSRef->__toString());
     }


### PR DESCRIPTION
Edited OSRef to add 2 new functions (cloned from toSixFigureRef) that allow 10m (8 figure) resolution and 1m (10 figure) resolution grid references from the easting / northing of OSRef.