### PR TITLE
Added support for tetrads to OSRef.php.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-coord/php-coord",
+    "name": "stevegoddard/php-coord",
     "description": "PHPCoord is a set of PHP functions for handling various co-ordinate systems and converting between them",
     "keywords": ["coord","geo", "wgs84", "osgb36", "latitude", "longitude", "grid ref", "utm", "itm" ,"gps"],
     "homepage": "https://github.com/dvdoug/PHPCoord",

--- a/src/OSRef.php
+++ b/src/OSRef.php
@@ -19,6 +19,7 @@ use function strpos;
 class OSRef extends TransverseMercator
 {
     private const GRID_LETTERS = 'VWXYZQRSTULMNOPFGHJKABCDE';
+    private const GRID_LETTERS_TETRAD = 'AFKQVBGLRWCHMSXDINTYEJPUZ';
 
     /**
      * @return RefEll
@@ -91,7 +92,9 @@ class OSRef extends TransverseMercator
      */
     public static function fromGridReference(string $ref): self
     {
-        if (strlen($ref) % 2 !== 0) {
+        if(strlen($ref) === 5) {
+            $tetrad = TRUE;
+        } elseif (strlen($ref) % 2 !== 0) {
             throw new LengthException('Grid ref must be an even number of characters');
         }
 
@@ -103,13 +106,26 @@ class OSRef extends TransverseMercator
         $minorEasting = strpos(self::GRID_LETTERS, $ref[1]) % 5 * 100000;
         $minorNorthing = (floor(strpos(self::GRID_LETTERS, $ref[1]) / 5)) * 100000;
 
+        //tetrad letter is 2km grid sq. THE GRID HAS A DIFFERENT ORIENTATION - starts botom left and runs bottom to top. Includes I but no O.
+        $tetradEasting = 0;
+        $tetradNorthing = 0;
+        if($tetrad) {
+            $tetradEasting = strpos(self::GRID_LETTERS_TETRAD, $ref[4]) % 5 * 2000;
+            $tetradNorthing = (floor(strpos(self::GRID_LETTERS_TETRAD, $ref[4]) / 5)) * 2000;
+        }
+
         //numbers are a division of that square into smaller and smaller pieces
-        $numericPortion = substr($ref, 2);
-        $numericPortionSize = strlen($numericPortion) / 2;
+        if($tetrad) {
+            $numericPortion = substr($ref, 2, 2);
+            $numericPortionSize = strlen($numericPortion) / 2;
+        } else {
+            $numericPortion = substr($ref, 2);
+            $numericPortionSize = strlen($numericPortion) / 2;
+        }
         $gridSizeInMetres = 1 * (10 ** (5 - $numericPortionSize));
 
-        $easting = $majorEasting + $minorEasting + (substr($numericPortion, 0, $numericPortionSize) * $gridSizeInMetres);
-        $northing = $majorNorthing + $minorNorthing + (substr($numericPortion, -$numericPortionSize, $numericPortionSize) * $gridSizeInMetres);
+        $easting = $majorEasting + $minorEasting + $tetradEasting + (substr($numericPortion, 0, $numericPortionSize) * $gridSizeInMetres);
+        $northing = $majorNorthing + $minorNorthing + $tetradNorthing + (substr($numericPortion, -$numericPortionSize, $numericPortionSize) * $gridSizeInMetres);
 
         return new static((int) $easting, (int) $northing);
     }

--- a/src/OSRef.php
+++ b/src/OSRef.php
@@ -159,10 +159,10 @@ class OSRef extends TransverseMercator
         $easting = str_pad((string) $this->x, 6, '0', STR_PAD_LEFT);
         $northing = str_pad((string) $this->y, 6, '0', STR_PAD_LEFT);
 
-        $adjustedX = $this->x + 1000000; // Takes us to REAL point of origin.
-        $adjustedY = $this->y + 500000; // Takes us to REAL point of origin.
-        $majorSquaresEast = floor($adjustedX / 500000); // Divide by 500000 and round down. Base of MAJOR square.
-        $majorSquaresNorth = floor($adjustedY / 500000); // Divide by 500000 and round down. Base of MAJOR square.
+        $adjustedX = $this->x + 1000000;
+        $adjustedY = $this->y + 500000;
+        $majorSquaresEast = floor($adjustedX / 500000);
+        $majorSquaresNorth = floor($adjustedY / 500000);
         $majorLetterIndex = (int) (5 * $majorSquaresNorth + $majorSquaresEast);
         $majorLetter = substr(self::GRID_LETTERS, $majorLetterIndex, 1);
 

--- a/src/OSRef.php
+++ b/src/OSRef.php
@@ -92,6 +92,7 @@ class OSRef extends TransverseMercator
      */
     public static function fromGridReference(string $ref): self
     {
+        $tetrad = FALSE;
         if(strlen($ref) === 5) {
             $tetrad = TRUE;
         } elseif (strlen($ref) % 2 !== 0) {

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -155,6 +155,15 @@ class OSRefTest extends TestCase
         self::assertEquals($expected, $OSRef->__toString());
     }
 
+    public function testToTetradString(): void
+    {
+        $OSRef = new OSRef(216604, 771209);
+
+        $expected = 'NN17Q';
+
+        self::assertEquals($expected, $OSRef->toGridReference(5));
+    }
+
     public function testIssue7(): void
     {
         $osRef = new OSRef(322000, 241000);

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -147,6 +147,14 @@ class OSRefTest extends TestCase
         self::assertEquals($expected, $OSRef->__toString());
     }
 
+    public function testFromTetradString(): void
+    {
+        $OSRef = OSRef::fromGridReference('SO24G');
+        $expected = '(322000, 242000)';
+
+        self::assertEquals($expected, $OSRef->__toString());
+    }
+
     public function testIssue7(): void
     {
         $osRef = new OSRef(322000, 241000);


### PR DESCRIPTION
Updated OSRef.php to accept tetrads and convert them to eastings / northings.
Updated OSRef.php to allow export to tetrad (toGridReference method).
The tetrad grid letters go in a different orientation to the main OS grid (start bottom left and run vertically). They also contain the letter I and exclude the letter O. 
A lot of wildlife data is recorded at tetrad resolution so hopefully this will be useful functionality.