### PR TITLE
Return OS ref with or without spaces

### DIFF
--- a/src/OSRef.php
+++ b/src/OSRef.php
@@ -115,6 +115,30 @@ class OSRef extends TransverseMercator
     }
 
     /**
+     * Grid reference without spaces. e.g. TG514131.
+     *
+     * @param int $length
+     *
+     * @return string
+     */
+    public function toGridReference(int $length): string
+    {
+        return implode('', $this->gridReference($length));
+    }
+    
+    /**
+     * Grid reference with spaces. e.g. TG 514 131.
+     *
+     * @param int $length
+     *
+     * @return string
+     */
+    public function toGridReferenceWithSpaces(int $length): string
+    {
+        return implode(' ', $this->gridReference($length));
+    }
+
+    /**
      * Convert this grid reference into a grid reference string of a
      * given length (2, 4, 6, 8 or 10) including the two-character
      * designation for the 100km square. e.g. TG514131.
@@ -123,7 +147,7 @@ class OSRef extends TransverseMercator
      *
      * @return string
      */
-    public function toGridReference(int $length): string
+    public function gridReference(int $length): array
     {
         if ($length % 2 !== 0) {
             throw new LengthException('Chosen length must be an even number');
@@ -147,7 +171,11 @@ class OSRef extends TransverseMercator
         $minorLetterIndex = (5 * $minorSquaresNorth + $minorSquaresEast);
         $minorLetter = substr(self::GRID_LETTERS, $minorLetterIndex, 1);
 
-        return $majorLetter . $minorLetter . substr($easting, 1, $halfLength) . substr($northing, 1, $halfLength);
+        return [
+            $majorLetter . $minorLetter,
+            substr($easting, 1, $halfLength),
+            substr($northing, 1, $halfLength),
+        ];
     }
 
     /**

--- a/src/OSRef.php
+++ b/src/OSRef.php
@@ -125,7 +125,7 @@ class OSRef extends TransverseMercator
     {
         return implode('', $this->gridReference($length));
     }
-    
+
     /**
      * Grid reference with spaces. e.g. TG 514 131.
      *

--- a/tests/OSRefTest.php
+++ b/tests/OSRefTest.php
@@ -124,6 +124,15 @@ class OSRefTest extends TestCase
         self::assertEquals($expected, $OSRef->toGridReference(10));
     }
 
+    public function testToEightFigureWithSpacesString(): void
+    {
+        $OSRef = new OSRef(216600, 771200);
+        
+        $expected = 'NN 1660 7120';
+
+        self::assertEquals($expected, $OSRef->toGridReferenceWithSpaces(8));
+    }
+
     public function testFromTenFigureString(): void
     {
         $OSRef = OSRef::fromGridReference('NN1660471209');


### PR DESCRIPTION
I have a use case where I’d like to present the OS reference in its format with spaces.

Changes are backwards compatible. Not sure if the name of the new method could be improved.