### PR TITLE
Fix backwards compatible namespace class aliases causing warnings when using with OPCache preloading

### DIFF
--- a/src/bc_namespace.php
+++ b/src/bc_namespace.php
@@ -9,14 +9,44 @@ declare(strict_types=1);
 namespace PHPCoord\Point;
 
 use function class_alias;
+use function class_exists;
 
-class_alias(Point::class, 'PHPCoord\Point');
-class_alias(BritishNationalGridPoint::class, 'PHPCoord\BritishNationalGridPoint');
-class_alias(CompoundPoint::class, 'PHPCoord\CompoundPoint');
-class_alias(GeocentricPoint::class, 'PHPCoord\GeocentricPoint');
-class_alias(GeographicPoint::class, 'PHPCoord\GeographicPoint');
-class_alias(IrishGridPoint::class, 'PHPCoord\IrishGridPoint');
-class_alias(IrishTransverseMercatorPoint::class, 'PHPCoord\IrishTransverseMercatorPoint');
-class_alias(ProjectedPoint::class, 'PHPCoord\ProjectedPoint');
-class_alias(UTMPoint::class, 'PHPCoord\UTMPoint');
-class_alias(VerticalPoint::class, 'PHPCoord\VerticalPoint');
+if (!class_exists('PHPCoord\Point')) {
+    class_alias(Point::class, 'PHPCoord\Point');
+}
+
+if (!class_exists('PHPCoord\BritishNationalGridPoint')) {
+    class_alias(BritishNationalGridPoint::class, 'PHPCoord\BritishNationalGridPoint');
+}
+
+if (!class_exists('PHPCoord\CompoundPoint')) {
+    class_alias(CompoundPoint::class, 'PHPCoord\CompoundPoint');
+}
+
+if (!class_exists('PHPCoord\GeocentricPoint')) {
+    class_alias(GeocentricPoint::class, 'PHPCoord\GeocentricPoint');
+}
+
+if (!class_exists('PHPCoord\GeographicPoint')) {
+    class_alias(GeographicPoint::class, 'PHPCoord\GeographicPoint');
+}
+
+if (!class_exists('PHPCoord\IrishGridPoint')) {
+    class_alias(IrishGridPoint::class, 'PHPCoord\IrishGridPoint');
+}
+
+if (!class_exists('PHPCoord\IrishTransverseMercatorPoint')) {
+    class_alias(IrishTransverseMercatorPoint::class, 'PHPCoord\IrishTransverseMercatorPoint');
+}
+
+if (!class_exists('PHPCoord\ProjectedPoint')) {
+    class_alias(ProjectedPoint::class, 'PHPCoord\ProjectedPoint');
+}
+
+if (!class_exists('PHPCoord\UTMPoint')) {
+    class_alias(UTMPoint::class, 'PHPCoord\UTMPoint');
+}
+
+if (!class_exists('PHPCoord\VerticalPoint')) {
+    class_alias(VerticalPoint::class, 'PHPCoord\VerticalPoint');
+}


### PR DESCRIPTION
Fixes https://github.com/dvdoug/PHPCoord/issues/68

Example of another project with a similar issue: https://github.com/Chi-teck/drupal-code-generator/issues/47 with fix https://github.com/Chi-teck/drupal-code-generator/pull/48